### PR TITLE
fix: add adaption to Realtek rtl8821cu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+usb-modeswitch-data (20191128-4deepin1) unstable; urgency=medium
+
+  * add-adaption-to-Realtek-rtl8821cu patch
+
+ -- LiChengGang <lichenggang@uniontech.com>  Thu, 28 Mar 2024 19:12:33 +0800
+
 usb-modeswitch-data (20191128-4) unstable; urgency=medium
 
   * Orphan package

--- a/debian/patches/add-adaption-to-Realtek-rtl8821cu-1
+++ b/debian/patches/add-adaption-to-Realtek-rtl8821cu-1
@@ -1,0 +1,23 @@
+
+--- usb-modeswitch-data-20191128.orig/40-usb_modeswitch.rules
++++ usb-modeswitch-data-20191128/40-usb_modeswitch.rules
+@@ -1256,4 +1256,7 @@ ATTR{idVendor}=="8888", ATTR{idProduct}=
+ # Aiko 81D, fw with wrong vendor ID
+ ATTR{idVendor}=="ed09", ATTR{idProduct}=="1021", RUN+="usb_modeswitch '/%k'"
+ 
++# Realtek rtl8821c
++ATTR{idVendor}=="0bda", ATTR{idProduct}=="1a2b", RUN+="usb_modeswitch '/%k'"
++
+ LABEL="modeswitch_rules_end"
+--- usb-modeswitch-data-20191128.orig/usb_modeswitch.d/0bda:1a2b
++++ usb-modeswitch-data-20191128/usb_modeswitch.d/0bda:1a2b
+@@ -1,6 +1,4 @@
+-# D-Link DWA-171 Wifi Dongle
+-TargetVendor=0x2001
+-TargetProduct=0x331d
++# Realtek rtl8821cu
++TargetVendor=0x0bda
++TargetProduct=0xc820
+ StandardEject=1
+-
+-

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Make-the-build-reproducible.patch
+add-adaption-to-Realtek-rtl8821cu-1


### PR DESCRIPTION
   Added the identification features of Realtek rtl8821cu,
and fixed the problem that Realtek rt18821 was recognized as a U disk

Log: 加入了rtl8821cu网卡的识别特征，修复了rt18821网卡被识别为U盘的问题